### PR TITLE
Forms v2 drupal user context

### DIFF
--- a/edoweb/edoweb.module
+++ b/edoweb/edoweb.module
@@ -95,6 +95,8 @@ function edoweb_init() {
       'thumbyServiceUrl' => variable_get('edoweb_thumby_url'),
       'zettelServiceUrl' => variable_get('edoweb_zettel_url'),	
       'formsServiceUrl' => variable_get('edoweb_forms_url'),
+      'formsV2UserId' => $user->uid,
+      'formsV2Token' => _edoweb_forms_v2_signature($user->uid),
     );
     drupal_add_js(array('edoweb' => $settings), 'setting');
     drupal_add_js(
@@ -315,6 +317,10 @@ function edoweb_field_extra_fields() {
  * Provides a wrapper on the edit form to add a new entity.
  */
 function edoweb_basic_add($bundle_type, $parent = NULL) {
+  $forms_v2_path = _edoweb_forms_v2_path($bundle_type);
+  if (NULL === $parent && NULL !== $forms_v2_path) {
+    drupal_goto(_edoweb_forms_v2_url($forms_v2_path));
+  }
   // Create a basic entity structure to be used and passed to the validation
   // and submission functions.
   $entity = entity_get_controller('edoweb_basic')->create(
@@ -679,6 +685,104 @@ function _edoweb_link_lastmodified($entity) {
 function _edoweb_compact_view($entity) {
   $entity_view = edoweb_basic_view($entity, 'compact');
   return drupal_render($entity_view);
+}
+
+function _edoweb_forms_v2_signature($uid) {
+  return drupal_hmac_base64('forms-v2-resource:' . $uid, drupal_get_private_key() . drupal_get_hash_salt());
+}
+
+function _edoweb_forms_v2_valid_signature($uid, $signature) {
+  return is_string($signature) && _edoweb_forms_v2_signature($uid) === $signature;
+}
+
+function _edoweb_forms_v2_url($path, $uid = NULL) {
+  global $user;
+  if (NULL === $uid) {
+    $uid = $user->uid;
+  }
+  $base_url = rtrim(variable_get('edoweb_forms_url'), '/');
+  $query = http_build_query(array(
+    'drupalUserId' => $uid,
+    'drupalToken' => _edoweb_forms_v2_signature($uid),
+  ));
+  return $base_url . $path . '?' . $query;
+}
+
+function _edoweb_forms_v2_path($bundle_type) {
+  $paths = array(
+    'article' => '/article/',
+    'researchData' => '/researchdata/',
+    'ktblData' => '/ktbldata/',
+    'monograph' => '/monograph/',
+  );
+  return isset($paths[$bundle_type]) ? $paths[$bundle_type] : NULL;
+}
+
+function _edoweb_forms_v2_start($bundle_type) {
+  $forms_v2_path = _edoweb_forms_v2_path($bundle_type);
+  if (NULL === $forms_v2_path) {
+    return drupal_not_found();
+  }
+  drupal_goto(_edoweb_forms_v2_url($forms_v2_path));
+}
+function _edoweb_forms_v2_create_resource() {
+  if ('POST' != $_SERVER['REQUEST_METHOD']) {
+    drupal_add_http_header('Status', '405 Method Not Allowed');
+    return drupal_json_output(array('error' => 'Only POST is allowed.'));
+  }
+
+  $data = json_decode(file_get_contents('php://input'), TRUE);
+  if (!is_array($data)) {
+    drupal_add_http_header('Status', '400 Bad Request');
+    return drupal_json_output(array('error' => 'Invalid JSON payload.'));
+  }
+
+  $uid = isset($_SERVER['HTTP_X_DRUPAL_USER_ID']) ? $_SERVER['HTTP_X_DRUPAL_USER_ID'] : '';
+  $signature = isset($_SERVER['HTTP_X_DRUPAL_FORMS_TOKEN']) ? $_SERVER['HTTP_X_DRUPAL_FORMS_TOKEN'] : '';
+  if (!ctype_digit((string) $uid) || !_edoweb_forms_v2_valid_signature($uid, $signature)) {
+    drupal_add_http_header('Status', '403 Forbidden');
+    return drupal_json_output(array('error' => 'Invalid forms.v2 Drupal context.'));
+  }
+
+  $account = user_load($uid);
+  if (!$account || !user_access('create edoweb_basic entities', $account)) {
+    drupal_add_http_header('Status', '403 Forbidden');
+    return drupal_json_output(array('error' => 'Access denied.'));
+  }
+
+  if (!isset($data['isDescribedBy']) || !is_array($data['isDescribedBy'])) {
+    $data['isDescribedBy'] = array();
+  }
+  $data['isDescribedBy']['createdBy'] = $uid;
+
+  $namespace = variable_get('edoweb_api_namespace');
+  $http_url = variable_get('edoweb_api_host') . '/resource/' . $namespace;
+  $http_options = array(
+    'method' => 'POST',
+    'data' => json_encode($data),
+    'headers' => array(
+      'Content-Type' => 'application/json',
+    ),
+  );
+
+  global $user;
+  $original_user = $user;
+  $user = $account;
+  $http_response = _edoweb_http_request($http_url, $http_options);
+  $user = $original_user;
+  if (isset($http_response->error)) {
+    drupal_add_http_header('Status', isset($http_response->code) ? $http_response->code : '500');
+    return drupal_json_output(array('error' => $http_response->error));
+  }
+
+  if (isset($http_response->code) && $http_response->code >= 400) {
+    drupal_add_http_header('Status', $http_response->code);
+    return drupal_json_output(array('error' => $http_response->data));
+  }
+
+  $location = isset($http_response->headers['location']) ? $http_response->headers['location'] : '';
+  $pid = $location ? substr($location, strrpos($location, '/') + 1) : '';
+  return drupal_json_output(array('pid' => $pid, 'location' => $location));
 }
 
 function _edoweb_http_request($request_url, $http_options) {

--- a/edoweb/js/edoweb.js
+++ b/edoweb/js/edoweb.js
@@ -67,6 +67,7 @@
        * Translations, these have to be defined here (i.e. in a behaviour)
        * in order for Drupal.t to pick them up.
        */
+	  translations['Add ktblData'] = Drupal.t('Add ktblData');
       translations['Add researchData'] = Drupal.t('Add researchData');
       translations['Add monograph'] = Drupal.t('Add monograph');
       translations['Add journal'] = Drupal.t('Add journal');

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -29,17 +29,23 @@
 			$('.tabs a[href$="/status"]').addClass('status');
 			
 			// replace formsUrl for integrate new forms
-			$('#main', context).each(function(){
-
+			$('.edoweb.entity.edit', context).each(function(){
+				
+				var bundle = $(this).attr('data-entity-bundle');
 				var resourceId = $('.table').attr('resource');				
 				var emimin = 0;
 				$('tr.ktbl', context).each(function(){
 					emimin =1;
 				})
 				
+				if(bundle == 'monograph' || 'article' || 'researchData'){
+					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/'+ bundle +'/'+ resourceId);
+				}
 				if(emimin >= 1){
 					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/ktbldata/' + resourceId);	
 				}
+				
+				
 			})
 
 

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -111,7 +111,8 @@
 					var instance = Drupal.settings.edoweb.fields[bundle][$(this).val()].instance;
 					var field = createField(instance);
 					if (bundle == 'researchData' || bundle == 'article' || bundle == 'monograph' || bundle == 'journal' || bundle == 'webpage') {
-						Drupal.zettel.useZettel(bundle, entity, context);
+						// Drupal.zettel.useZettel(bundle, entity, context);
+						$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl + "/" + bundle + "/" + resourceId);
 
 					} else {
 						activateFields(field, bundle, context);

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -29,18 +29,18 @@
 			$('.tabs a[href$="/status"]').addClass('status');
 			
 			// replace formsUrl for integrate new forms
-			$('.edoweb.entity.edit', context).each(function(){
+			$('#main', context).each(function(){
 				
 				var bundle = $(this).attr('data-entity-bundle');
 				var resourceId = $('.table').attr('resource');				
 				var emimin = 0;
-				//$('tr.ktbl', context).each(function(){
-					//emimin =1;
-				//})
+				$('tr.ktbl', context).each(function(){
+					emimin =1;
+				})
 				
-				if(bundle == 'monograph' || 'article' || 'researchData'){
-					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/'+ bundle +'/'+ resourceId);
-				}
+				//if(bundle == 'monograph' || 'article' || 'researchData'){
+				//	$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/'+ bundle +'/'+ resourceId);
+				//}
 				
 				if(emimin >= 1){
 					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/ktbldata/' + resourceId);	

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -31,16 +31,16 @@
 			// replace formsUrl for integrate new forms
 			$('#main', context).each(function(){
 				
-				var bundle = $(this).attr('data-entity-bundle');
+				var bundle = $('.edoweb.entity.default').attr('data-entity-bundle');
 				var resourceId = $('.table').attr('resource');				
 				var emimin = 0;
 				$('tr.ktbl', context).each(function(){
 					emimin =1;
 				})
 				
-				//if(bundle == 'monograph' || 'article' || 'researchData'){
-				//	$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/'+ bundle +'/'+ resourceId);
-				//}
+				if(bundle == 'monograph' || 'article' || 'researchData'){
+					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/'+ bundle +'/'+ resourceId);
+				}
 				
 				if(emimin >= 1){
 					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/ktbldata/' + resourceId);	

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -41,6 +41,7 @@
 				if(bundle == 'monograph' || 'article' || 'researchData'){
 					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/'+ bundle +'/'+ resourceId);
 				}
+				
 				if(emimin >= 1){
 					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/ktbldata/' + resourceId);	
 				}

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -31,15 +31,11 @@
 			// replace formsUrl for integrate new forms
 			$('#main', context).each(function(){
 
-				var resourceId = $('.table').attr('resource');				
-				var emimin = 0;
-				$('tr.ktbl', context).each(function(){
-					emimin =1;
-				})
-				
-				if(emimin >= 1){
-					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/ktbldata/' + resourceId);	
-				}
+				var bundle = $(this).attr('data-entity-bundle');
+				var resourceId = $('.table').attr('resource');
+				if(bundle == 'ktblData' || 'researchData' || 'monograph' || 'article'){
+					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl + '/' + bundle + '/' + resourceId);						
+				}				
 			})
 
 
@@ -110,7 +106,7 @@
 				additional_fields.change(function() {
 					var instance = Drupal.settings.edoweb.fields[bundle][$(this).val()].instance;
 					var field = createField(instance);
-					if (bundle == 'ktblData' || 'researchData' || bundle == 'article' || bundle == 'monograph') {
+					if (bundle == 'researchData' || bundle == 'article' || bundle == 'monograph') {
 						// Drupal.zettel.useZettel(bundle, entity, context);
 						$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl + "/" + bundle + "/" + resourceId);
 

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -34,9 +34,9 @@
 				var bundle = $(this).attr('data-entity-bundle');
 				var resourceId = $('.table').attr('resource');				
 				var emimin = 0;
-				$('tr.ktbl', context).each(function(){
-					emimin =1;
-				})
+				//$('tr.ktbl', context).each(function(){
+					//emimin =1;
+				//})
 				
 				if(bundle == 'monograph' || 'article' || 'researchData'){
 					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/'+ bundle +'/'+ resourceId);

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -38,8 +38,12 @@
 					emimin =1;
 				})
 				
-				if(bundle == 'monograph' || 'article' || 'researchData'){
+				if(bundle == 'article' || 'researchData'){
 					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/'+ bundle +'/'+ resourceId);
+				}
+				
+				if(bundle == 'monograph'){
+					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/monograph/');
 				}
 				
 				if(emimin >= 1){

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -31,9 +31,11 @@
 			// replace formsUrl for integrate new forms
 			$('#main', context).each(function(){
 
+				var bundle = $(this).attr('data-entity-bundle');
 				var resourceId = $('.table').attr('resource');
 				if(bundle == 'ktblData' || 'researchData' || 'monograph' || 'article'){
-					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl + '/' + bundle + '/' + resourceId);						
+					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl + '/' + bundle + '/' + resourceId);	
+					
 				}				
 			})
 

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -28,10 +28,10 @@
 			$('.tabs a[href$="/edit"]').addClass('edit');
 			$('.tabs a[href$="/status"]').addClass('status');
 			
+			var bundle = $(this).attr('data-entity-bundle');
 			// replace formsUrl for integrate new forms
 			$('#main', context).each(function(){
 
-				var bundle = $(this).attr('data-entity-bundle');
 				var resourceId = $('.table').attr('resource');
 				if(bundle == 'ktblData' || 'researchData' || 'monograph' || 'article'){
 					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl + '/' + bundle + '/' + resourceId);						

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -31,12 +31,15 @@
 			// replace formsUrl for integrate new forms
 			$('#main', context).each(function(){
 
-				var bundle = $(this).attr('data-entity-bundle');
-				var resourceId = $('.table').attr('resource');
-				if(bundle == 'ktblData' || 'researchData' || 'monograph' || 'article'){
-					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl + '/' + bundle + '/' + resourceId);	
-					
-				}				
+				var resourceId = $('.table').attr('resource');				
+				var emimin = 0;
+				$('tr.ktbl', context).each(function(){
+					emimin =1;
+				})
+				
+				if(emimin >= 1){
+					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/ktbldata/' + resourceId);	
+				}
 			})
 
 

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -28,7 +28,6 @@
 			$('.tabs a[href$="/edit"]').addClass('edit');
 			$('.tabs a[href$="/status"]').addClass('status');
 			
-			var bundle = $(this).attr('data-entity-bundle');
 			// replace formsUrl for integrate new forms
 			$('#main', context).each(function(){
 

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -110,7 +110,7 @@
 				additional_fields.change(function() {
 					var instance = Drupal.settings.edoweb.fields[bundle][$(this).val()].instance;
 					var field = createField(instance);
-					if (bundle == 'researchData' || bundle == 'article' || bundle == 'monograph') {
+					if (bundle == 'researchData' || bundle == 'article' || bundle == 'monograph' || bundle == 'journal' || bundle == 'webpage') {
 						// Drupal.zettel.useZettel(bundle, entity, context);
 						$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl + "/" + bundle + "/" + resourceId);
 

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -110,7 +110,7 @@
 				additional_fields.change(function() {
 					var instance = Drupal.settings.edoweb.fields[bundle][$(this).val()].instance;
 					var field = createField(instance);
-					if (bundle == 'researchData' || bundle == 'article' || bundle == 'monograph' || bundle == 'journal' || bundle == 'webpage') {
+					if (bundle == 'ktblData' || 'researchData' || bundle == 'article' || bundle == 'monograph') {
 						// Drupal.zettel.useZettel(bundle, entity, context);
 						$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl + "/" + bundle + "/" + resourceId);
 

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -46,7 +46,7 @@
 				})
 				
 				if(bundle == 'article' || bundle == 'researchData'){
-					$('.edit').attr('href', formsUrl('/'+ bundle +'/'+ resourceId));
+					$('.edit').attr('href', formsUrl('/'+ formsPath(bundle) +'/'+ resourceId));
 				}
 				
 				if(bundle == 'monograph'){
@@ -130,7 +130,7 @@
 					var field = createField(instance);
 					if (bundle == 'researchData' || bundle == 'article' || bundle == 'monograph' || bundle == 'journal' || bundle == 'webpage') {
 						// Drupal.zettel.useZettel(bundle, entity, context);
-						$('.edit').attr('href', formsUrl("/" + bundle + "/" + resourceId));
+						$('.edit').attr('href', formsUrl("/" + formsPath(bundle) + "/" + resourceId));
 
 					} else {
 						activateFields(field, bundle, context);
@@ -733,6 +733,16 @@
 			}
 		});
 		Drupal.edoweb.pending_requests.push(request);
+	}
+	
+	function formsPath(bundle) {
+		if (bundle == 'researchData') {
+			return 'researchdata';
+		}
+		if (bundle == 'ktblData') {
+			return 'ktbldata';
+		}
+		return bundle;
 	}
 
 })(jQuery);

--- a/edoweb/js/edoweb_edit.js
+++ b/edoweb/js/edoweb_edit.js
@@ -21,6 +21,13 @@
 
 	Drupal.behaviors.edoweb_edit = {
 		attach: function(context, settings) {
+			function formsUrl(path) {
+				var url = Drupal.settings.edoweb.formsServiceUrl + path;
+				url += (url.indexOf('?') === -1 ? '?' : '&') + 'drupalUserId='
+						+ encodeURIComponent(Drupal.settings.edoweb.formsV2UserId);
+				url += '&drupalToken=' + encodeURIComponent(Drupal.settings.edoweb.formsV2Token);
+				return url;
+			}
 			
 			// add missing classes to <a> in menu tabs
 			$('.tabs a[href$="/access"]').addClass('access');
@@ -38,16 +45,16 @@
 					emimin =1;
 				})
 				
-				if(bundle == 'article' || 'researchData'){
-					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/'+ bundle +'/'+ resourceId);
+				if(bundle == 'article' || bundle == 'researchData'){
+					$('.edit').attr('href', formsUrl('/'+ bundle +'/'+ resourceId));
 				}
 				
 				if(bundle == 'monograph'){
-					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/monograph/');
+					$('.edit').attr('href', formsUrl('/monograph/'));
 				}
 				
 				if(emimin >= 1){
-					$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl +'/ktbldata/' + resourceId);	
+					$('.edit').attr('href', formsUrl('/ktbldata/' + resourceId));
 				}
 				
 				
@@ -123,7 +130,7 @@
 					var field = createField(instance);
 					if (bundle == 'researchData' || bundle == 'article' || bundle == 'monograph' || bundle == 'journal' || bundle == 'webpage') {
 						// Drupal.zettel.useZettel(bundle, entity, context);
-						$('.edit').attr('href', Drupal.settings.edoweb.formsServiceUrl + "/" + bundle + "/" + resourceId);
+						$('.edit').attr('href', formsUrl("/" + bundle + "/" + resourceId));
 
 					} else {
 						activateFields(field, bundle, context);

--- a/edoweb/php/edowebMenu.php
+++ b/edoweb/php/edowebMenu.php
@@ -127,6 +127,20 @@ function edoweb_menu() {
         'type' => MENU_LOCAL_TASK,
     );
     
+    // Start forms.v2 through Drupal so the current user can be signed.
+    $items['edoweb/forms-v2/start/%'] = array(
+        'page callback' => '_edoweb_forms_v2_start',
+        'page arguments' => array(3),
+        'access arguments' => array('create edoweb_basic entities'),
+        'type' => MENU_CALLBACK,
+    );
+    // JSON create proxy for forms.v2. Drupal owns the user session.
+    $items['edoweb/forms-v2/resource'] = array(
+        'page callback' => '_edoweb_forms_v2_create_resource',
+        'access callback' => TRUE,
+        'type' => MENU_CALLBACK,
+    );
+
     // GND Autocompletion
     $items['edoweb/autocomplete'] = array(
         'page callback' => '_edoweb_autocomplete', //edoweb.module

--- a/edoweb_storage/edoweb_storage.module
+++ b/edoweb_storage/edoweb_storage.module
@@ -153,14 +153,14 @@ function edoweb_storage_configuration_form($form, &$form_state) {
     '#required' => FALSE,
   );
 
-  // Text field for deepviewer URL.
+  // Text field for new Forms URL.
   $form['edoweb_forms_url'] = array(
       '#type' => 'textfield',
       '#default_value' => variable_get(
           'edoweb_forms_url',
-          variable_get('edoweb_api_host') . '/ktbldata'
+          variable_get('edoweb_api_host')
           ),
-      '#title' => t('ktbl Data Form URL'),
+      '#title' => t('Spring Boot based Form URL'),
       '#description' => t('The full URL to the new forms service'),
       '#size' => 40,
       '#maxlength' => 120,


### PR DESCRIPTION
In diesem Branch wurde die Übergabe der Drupal-User-ID für forms.v2 ergänzt. Dadurch kann Drupal den angemeldeten Benutzerkontext an das neue Formular weitergeben und eingehende Formular-Submissions dem korrekten Drupal-User zuordnen. Die Kommunikation zwischen Drupal und forms.v2 wurde dafür so angepasst, dass neue Ressourcen nicht mehr ohne Benutzerkontext angelegt werden.

Hinweis: Diesen Branch erst mergen, wenn patch1 in forms.v2 bereits gemergt wurde.